### PR TITLE
Disable `CGO` for release build.

### DIFF
--- a/makefile
+++ b/makefile
@@ -26,7 +26,7 @@ build:
 
 build-release:
 	# Request non-dev-build.
-	BUILD_DEV=0 $(MAKE) build
+	BUILD_DEV=0 CGO_ENABLED=0 $(MAKE) build
 	# Pack the built binary via upx (we get smaller binary).
 	upx-ucl ./$(BINARY_PATH)
 


### PR DESCRIPTION
Using `CGO_ENABLED=0` enabled statically linked binary. Then final binary will no longer require any external dependencies. Which is better for multi target builds.