### PR TITLE
Allow also numeric type values in json config

### DIFF
--- a/internal/reporter.go
+++ b/internal/reporter.go
@@ -28,6 +28,8 @@ func buildPayload(
 			if err == nil {
 				template[k] = _v
 			}
+		case float64:
+			template[k] = v
 		case StringKeyMap:
 			template[k] = buildPayload(v, vars)
 		case []interface{}:


### PR DESCRIPTION
Allow also numeric type values in json config.

e.g.
`"timeseries": 3600,`