### PR TITLE
Args parser exits if any arg is not valid

### DIFF
--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ func initialize() {
 	err := parser.Parse(os.Args)
 	if err != nil {
 		fmt.Print(parser.Usage(err))
-		return
+		os.Exit(1)
 	}
 
 	settings := &internal.Settings


### PR DESCRIPTION
Args parser exits if any arg is not valid.

```
$ ./reporter --foo
Maxon Reporter-Go [version 2023.06.22.1607] by Premysl Karbula

unknown arguments --foo
usage: reporter [-h|--help] [-c|--config "<value>"] [-v|--verbose] [-t|--try]
                [-f|--foreground]

                Maxon Reporter

Arguments:

  -h  --help        Print help information
  -c  --config      Path to config.json
  -v  --verbose     Enable verbose mode. Default: false
  -t  --try         Do a single run and exit. Default: false
  -f  --foreground  Run in foreground without daemonization. Default: false

(parser_args_exit) 16:08:30 ~/Projects/maxon-reporter-go/build

$ echo $?
1
```
