### PR TITLE
Fixed DaemonMode return to exit

### DIFF
--- a/main.go
+++ b/main.go
@@ -115,7 +115,7 @@ func main() {
 			// We're the parent process - we'll tell the client the reporter
 			// is being daemonized and then exit.
 			fmt.Println("Daemonizing ...")
-			return
+			os.Exit(0)
 		}
 	}
 


### PR DESCRIPTION
Fixed bahaviour, when after successful demonizing, reporter keep running on foreground.